### PR TITLE
Add initialize method to classes made before the base Game instance

### DIFF
--- a/src/bot_resources/bot.py
+++ b/src/bot_resources/bot.py
@@ -7,7 +7,6 @@ from typing import Optional, TYPE_CHECKING
 from bot_resources.bot_constants import BotDifficulty
 from deck.cards.item_card import ItemCard
 from locations.location import Location
-from pieces.building import Building
 from player_resources.player import Player
 
 if TYPE_CHECKING:
@@ -25,7 +24,7 @@ class Bot(Player, ABC):
     order_card: Optional['Card']
     traits: list['Trait']
 
-    def __init__(self, game: 'Game', faction: 'Faction', piece_stock: 'PieceStock' = None,
+    def __init__(self, game: Optional['Game'], faction: 'Faction', piece_stock: 'PieceStock' = None,
                  difficulty: 'BotDifficulty' = BotDifficulty.BEGINNER, traits: list['Trait'] = None) -> None:
         if traits is None:
             traits = []
@@ -77,13 +76,15 @@ class Bot(Player, ABC):
                                    clearing.can_place_pieces(self, pieces_to_place)]
 
         if not valid_placing_clearings:
-            return
+            return False
         clearing_snare = valid_placing_clearings[0].get_snare()
         if clearing_snare:
             valid_placing_clearings[0].remove_pieces(self, [clearing_snare])
             self.add_victory_points(1)
+            return False
         else:
             self.supply.relocate_pieces(self, pieces_to_place, valid_placing_clearings[0])
+            return True
 
     def place_pieces_spread_among_clearings(self, pieces_to_place: list['Piece'], sorted_clearings: list['Clearing'],
                                             ignore_building_slots: bool = False) -> None:

--- a/src/bot_resources/bot_factions/automated_alliance/automated_alliance_player.py
+++ b/src/bot_resources/bot_factions/automated_alliance/automated_alliance_player.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import random
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from battle_utils import DamageResult, RollResult
 from bot_resources.bot import Bot
@@ -39,7 +39,8 @@ class AutomatedAlliancePlayer(Bot):
 
     SYMPATHY_SCORES = [0, 1, 1, 1, 1, 2, 2, 3, 3, 4]
 
-    def __init__(self, game: Game, difficulty: 'BotDifficulty' = None, traits: list['Trait'] = None) -> None:
+    def __init__(self, game: Optional['Game'], difficulty: 'BotDifficulty' = None,
+                 traits: list['Trait'] = None) -> None:
         piece_stock = AutomatedAlliancePieceStock(self)
         super().__init__(game, Faction.AUTOMATED_ALLIANCE, piece_stock, difficulty=difficulty, traits=traits)
 
@@ -322,6 +323,7 @@ class AutomatedAlliancePlayer(Bot):
             if isinstance(piece, Base):
                 self.game.log(f'{self} suffers a crackdown in {piece.suit}.', logging_faction=self.faction)
                 for sympathy in self.piece_stock.get_sympathy():
-                    if isinstance(sympathy.location, Clearing) and sympathy.location.suit == piece.suit:
+                    if (isinstance(sympathy.location, Clearing) and sympathy.location.suit == piece.suit and
+                            sympathy not in pieces):
                         sympathy.location.remove_pieces(self, [sympathy])
         self.supply.add_pieces(self, pieces)

--- a/src/bot_resources/bot_factions/electric_eyrie/electric_eyrie_player.py
+++ b/src/bot_resources/bot_factions/electric_eyrie/electric_eyrie_player.py
@@ -320,7 +320,7 @@ class ElectricEyriePlayer(Bot):
                 clearing.remove_pieces(player, defenseless_pieces)
 
     def swoop(self) -> None:
-        warrior_count_to_place = max(2, len(self.get_unplaced_warriors()))
+        warrior_count_to_place = min(2, len(self.get_unplaced_warriors()))
         warriors_to_place = self.get_unplaced_warriors()[:warrior_count_to_place]
         clearings_without_own_pieces = [clearing for clearing in self.game.clearings() if
                                         clearing.get_piece_count_for_player(self) == 0]

--- a/src/bot_resources/bot_factions/electric_eyrie/electric_eyrie_player.py
+++ b/src/bot_resources/bot_factions/electric_eyrie/electric_eyrie_player.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import random
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from bot_resources.bot import Bot
 from bot_resources.bot_constants import BotDifficulty
@@ -39,7 +39,8 @@ class ElectricEyriePlayer(Bot):
     turmoil: bool
     deal_extra_hit: bool
 
-    def __init__(self, game: Game, difficulty: 'BotDifficulty' = None, traits: list['Trait'] = None) -> None:
+    def __init__(self, game: Optional['Game'], difficulty: 'BotDifficulty' = None,
+                 traits: list['Trait'] = None) -> None:
         piece_stock = ElectricEyriePieceStock(self)
         super().__init__(game, Faction.ELECTRIC_EYRIE, piece_stock, difficulty=difficulty, traits=traits)
 

--- a/src/bot_resources/bot_factions/mechanical_marquise_v2/mechanical_marquise_v2_player.py
+++ b/src/bot_resources/bot_factions/mechanical_marquise_v2/mechanical_marquise_v2_player.py
@@ -40,7 +40,8 @@ class MechanicalMarquiseV2Player(Bot):
     crafted_items: list[ItemToken]
     built_building_this_turn: bool
 
-    def __init__(self, game: Game, difficulty: 'BotDifficulty' = None, traits: list['Trait'] = None) -> None:
+    def __init__(self, game: Optional['Game'], difficulty: 'BotDifficulty' = None,
+                 traits: list['Trait'] = None) -> None:
         piece_stock = MechanicalMarquiseV2PieceStock(self)
         super().__init__(game, Faction.MECHANICAL_MARQUISE_2_0, piece_stock, difficulty=difficulty, traits=traits)
 

--- a/src/bot_resources/bot_factions/mechanical_marquise_v2/mechanical_marquise_v2_player.py
+++ b/src/bot_resources/bot_factions/mechanical_marquise_v2/mechanical_marquise_v2_player.py
@@ -173,14 +173,14 @@ class MechanicalMarquiseV2Player(Bot):
         clearing.remove_pieces(self, removed_pieces)
         if not is_attacker:
             # Hospitals only works as the defender
-            self.apply_field_hospitals(removed_pieces)
+            self.apply_field_hospitals([piece for piece in removed_pieces if isinstance(piece, Warrior)])
         return DamageResult(removed_pieces=removed_pieces, points_awarded=points_awarded)
 
     def apply_field_hospitals(self, removed_warriors: list['Warrior']) -> None:
         if self.has_trait(TRAIT_HOSPITALS):
             keep_clearing = self.piece_stock.get_keep().location
             if isinstance(keep_clearing, Clearing) and len(removed_warriors) >= 2:
-                keep_clearing.add_piece(self, removed_warriors[0])
+                keep_clearing.add_piece(self, removed_warriors[0], log=True)
 
     ###################
     #                 #

--- a/src/bot_resources/bot_factions/vagabot/vagabot_characters.py
+++ b/src/bot_resources/bot_factions/vagabot/vagabot_characters.py
@@ -24,9 +24,6 @@ class VagabotCharacter(ABC):
     def perform_special_action(self):
         pass
 
-    def set_player(self, player: 'VagabotPlayer') -> None:
-        self.player = player
-
     def can_perform_special_action(self) -> bool:
         return False
 

--- a/src/bot_resources/bot_factions/vagabot/vagabot_player.py
+++ b/src/bot_resources/bot_factions/vagabot/vagabot_player.py
@@ -17,6 +17,7 @@ from locations.clearing import Clearing
 from locations.forest import Forest
 from pieces.item_token import ItemToken
 from pieces.warrior import Warrior
+from player_resources.player import Player
 from player_resources.supply import Supply
 from sort_utils import sort_clearings_by_enemy_pieces, \
     sort_clearings_by_priority, sort_paths_by_lexicographic_priority, \
@@ -28,7 +29,6 @@ if TYPE_CHECKING:
     from game import Game
     from locations.location import Location
     from pieces.piece import Piece
-    from player_resources.player import Player
 
 
 class VagabotPlayer(Bot):

--- a/src/bot_resources/bot_factions/vagabot/vagabot_player.py
+++ b/src/bot_resources/bot_factions/vagabot/vagabot_player.py
@@ -45,7 +45,7 @@ class VagabotPlayer(Bot):
     has_slipped: bool
     has_battled: bool
 
-    def __init__(self, game: 'Game', character: 'VagabotCharacter', difficulty: 'BotDifficulty' = None,
+    def __init__(self, game: Optional['Game'], character: 'VagabotCharacter', difficulty: 'BotDifficulty' = None,
                  traits: list['Trait'] = None) -> None:
         piece_stock = VagabotPieceStock(self)
         super().__init__(game, Faction.VAGABOT, piece_stock, difficulty=difficulty, traits=traits)
@@ -53,13 +53,21 @@ class VagabotPlayer(Bot):
         self.has_slipped = False
         self.has_battled = False
         self.character = character
-        self.character.set_player(self)
-        self.quest = self.game.quest_deck.draw_quest_card()
+        self.character.player = self
+        if game:
+            self.quest = self.game.quest_deck.draw_quest_card()
+        else:
+            self.quest = None
         self.satchel = Satchel(self.game, self)
 
         for _ in range(self.character.starting_item_amount):
             random_item = random.choice(list(Item))
             self.satchel.add_item(ItemToken(random_item, is_starting_item=True))
+
+    def initialize_game(self, game: 'Game') -> None:
+        self.game = game
+        self.supply.game = game
+        self.quest = self.game.quest_deck.draw_quest_card()
 
     def setup(self) -> None:
         maximum_adjacent_clearings = 0

--- a/src/game.py
+++ b/src/game.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import logging
 from typing import Optional, TYPE_CHECKING
 
@@ -7,7 +8,7 @@ from bot_resources.bot_constants import BotDifficulty
 from bot_resources.bot_factions.automated_alliance.automated_alliance_player import AutomatedAlliancePlayer
 from bot_resources.bot_factions.electric_eyrie.electric_eyrie_player import ElectricEyriePlayer
 from bot_resources.bot_factions.mechanical_marquise_v2.mechanical_marquise_v2_player import MechanicalMarquiseV2Player
-from bot_resources.bot_factions.vagabot.vagabot_characters import VagabotThief, VagabotRanger
+from bot_resources.bot_factions.vagabot.vagabot_characters import VagabotThief
 from bot_resources.bot_factions.vagabot.vagabot_player import VagabotPlayer
 from constants import Item, Faction
 from deck.base_deck import BaseDeck
@@ -72,7 +73,7 @@ class Game:
         if faction == Faction.AUTOMATED_ALLIANCE:
             return AutomatedAlliancePlayer(self, BotDifficulty.MASTER)
         if faction == Faction.VAGABOT:
-            return VagabotPlayer(self, VagabotRanger(), BotDifficulty.MASTER)
+            return VagabotPlayer(self, VagabotThief(), BotDifficulty.MASTER)
 
     def clearings(self) -> list['Clearing']:
         return self.board_map.clearings

--- a/src/game.py
+++ b/src/game.py
@@ -7,7 +7,7 @@ from bot_resources.bot_constants import BotDifficulty
 from bot_resources.bot_factions.automated_alliance.automated_alliance_player import AutomatedAlliancePlayer
 from bot_resources.bot_factions.electric_eyrie.electric_eyrie_player import ElectricEyriePlayer
 from bot_resources.bot_factions.mechanical_marquise_v2.mechanical_marquise_v2_player import MechanicalMarquiseV2Player
-from bot_resources.bot_factions.vagabot.vagabot_characters import VagabotThief
+from bot_resources.bot_factions.vagabot.vagabot_characters import VagabotThief, VagabotRanger
 from bot_resources.bot_factions.vagabot.vagabot_player import VagabotPlayer
 from constants import Item, Faction
 from deck.base_deck import BaseDeck
@@ -38,7 +38,7 @@ class Game:
 
     def __init__(self, players: list['Player'] = None, factions: list['Faction'] = None) -> None:
         self.logger = logging.getLogger(__name__)
-        # logging.basicConfig(level=logging.INFO)
+        logging.basicConfig(level=logging.INFO)
 
         self.deck = BaseDeck(self)
         self.quest_deck = QuestDeck()
@@ -64,15 +64,6 @@ class Game:
         for player in sort_players_by_setup_order(self.players):
             player.setup()
 
-        while not self.winner:
-            self.log(f'--{self.turn_player}--')
-            self.turn_player.take_turn()
-            next_turn_player_index = self.turn_order.index(self.turn_player) + 1
-            next_turn_player_index %= len(self.turn_order)
-            self.turn_player = self.turn_order[next_turn_player_index]
-            for player in self.players:
-                player.between_turns()
-
     def build_player_by_faction(self, faction: Faction) -> 'Player':
         if faction == Faction.MECHANICAL_MARQUISE_2_0:
             return MechanicalMarquiseV2Player(self, BotDifficulty.MASTER)
@@ -81,7 +72,7 @@ class Game:
         if faction == Faction.AUTOMATED_ALLIANCE:
             return AutomatedAlliancePlayer(self, BotDifficulty.MASTER)
         if faction == Faction.VAGABOT:
-            return VagabotPlayer(self, VagabotThief(), BotDifficulty.MASTER)
+            return VagabotPlayer(self, VagabotRanger(), BotDifficulty.MASTER)
 
     def clearings(self) -> list['Clearing']:
         return self.board_map.clearings
@@ -107,6 +98,16 @@ class Game:
         for item_token in self.item_supply:
             if item_token.item == item:
                 return item_token
+
+    def play(self) -> None:
+        while not self.winner:
+            self.log(f'--{self.turn_player}--')
+            self.turn_player.take_turn()
+            next_turn_player_index = self.turn_order.index(self.turn_player) + 1
+            next_turn_player_index %= len(self.turn_order)
+            self.turn_player = self.turn_order[next_turn_player_index]
+            for player in self.players:
+                player.between_turns()
 
     def win(self, player: 'Player') -> None:
         if self.winner:

--- a/src/locations/location.py
+++ b/src/locations/location.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from player_resources.player_piece_map import PlayerPieceMap
 
@@ -13,10 +13,10 @@ if TYPE_CHECKING:
 
 
 class Location:
-    game: Game
+    game: 'Game'
     pieces: dict['Player', 'PlayerPieceMap']
 
-    def __init__(self, game: 'Game') -> None:
+    def __init__(self, game: Optional['Game']) -> None:
         self.game = game
         self.pieces = {}
 

--- a/src/player_resources/player.py
+++ b/src/player_resources/player.py
@@ -81,7 +81,7 @@ class Player(ABC):
         self.victory_points = max(0, self.victory_points + victory_points)
         if self.victory_points >= 30:
             self.game.win(self)
-        if victory_points > 0:
+        if victory_points != 0:
             self.game.log(f'{self} now has total {self.victory_points} VP.', logging_faction=self.faction)
 
     def get_unplaced_pieces(self) -> list['Piece']:

--- a/src/player_resources/player.py
+++ b/src/player_resources/player.py
@@ -31,7 +31,7 @@ class Player(ABC):
     revealed_cards: list['Card']
     crafted_items: list['ItemToken']
 
-    def __init__(self, game: 'Game', faction: 'Faction', piece_stock: 'PieceStock' = None) -> None:
+    def __init__(self, game: Optional['Game'], faction: 'Faction', piece_stock: 'PieceStock' = None) -> None:
         if piece_stock is None:
             piece_stock = PieceStock(self)
 
@@ -45,6 +45,10 @@ class Player(ABC):
         self.hand = []
         self.revealed_cards = []
         self.crafted_items = []
+
+    def initialize_game(self, game: 'Game') -> None:
+        self.game = game
+        self.supply.game = game
 
     def setup(self) -> None:
         self.supply.add_pieces(self, self.piece_stock.pieces)

--- a/src/player_resources/supply.py
+++ b/src/player_resources/supply.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Type, TYPE_CHECKING
+from typing import Type, TYPE_CHECKING, Optional
 
 from locations.location import Location
 
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 class Supply(Location):
-    def __init__(self, game: 'Game', player: 'Player') -> None:
+    def __init__(self, game: Optional['Game'], player: 'Player') -> None:
         super().__init__(game)
         self.player = player
 


### PR DESCRIPTION
- Makes the game an optional component of these classes (So players can be created before the game is)
- Fixes a bug in removing sympathy due to Crackdown
- Fixes a bug in Field Hospitals
- Fixes a bug where swoop would recruit all warriors
- Moves the game playing step outside of its initialization